### PR TITLE
Adding sys_close variable assignment for systems running a kver post sys_close removal.

### DIFF
--- a/diamorphine.c
+++ b/diamorphine.c
@@ -3,13 +3,14 @@
 #include <linux/syscalls.h>
 #include <linux/dirent.h>
 #include <linux/slab.h>
-#include <linux/version.h> 
+#include <linux/version.h>
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 13, 0)
 	#include <asm/uaccess.h>
 #endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0)
 	#include <linux/proc_ns.h>
+    unsigned long sys_close = (unsigned long)__close_fd;
 #else
 	#include <linux/proc_fs.h>
 #endif


### PR DESCRIPTION
`sys_close` was removed from the kernel and replaced with ksys_close and an exported symbol (`__close_fd`). Here's the patch which removed the availability of `sys_close`: https://lore.kernel.org/patchwork/patch/937297/ 

w/o this on my localhost, i get an error when running `make`:

```⇒  make
/usr/bin/make -C /lib/modules/4.18.19-100.fc27.x86_64/build M=/home/th3v0id/Personal/Repos/Diamorphine modules
make[1]: Entering directory '/usr/src/kernels/4.18.19-100.fc27.x86_64'
  CC [M]  /home/th3v0id/Personal/Repos/Diamorphine/diamorphine.o
/home/th3v0id/Personal/Repos/Diamorphine/diamorphine.c: In function ‘get_syscall_table_bf’:
/home/th3v0id/Personal/Repos/Diamorphine/diamorphine.c:42:30: error: ‘sys_close’ undeclared (first use in this function); did you mean ‘ksys_close’?
  for (i = (unsigned long int)sys_close; i < ULONG_MAX;
                              ^~~~~~~~~
                              ksys_close
/home/th3v0id/Personal/Repos/Diamorphine/diamorphine.c:42:30: note: each undeclared identifier is reported only once for each function it appears in
make[2]: *** [scripts/Makefile.build:324: /home/th3v0id/Personal/Repos/Diamorphine/diamorphine.o] Error 1
make[1]: *** [Makefile:1509: _module_/home/th3v0id/Personal/Repos/Diamorphine] Error 2
make[1]: Leaving directory '/usr/src/kernels/4.18.19-100.fc27.x86_64'
make: *** [Makefile:7: all] Error 2
```

here's my uname -a output:
> Linux 90h 4.18.19-100.fc27.x86_64 #1 SMP Wed Nov 14 22:04:34 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux

after applying this change, the build completes successfully:

```⇒  make
/usr/bin/make -C /lib/modules/4.18.19-100.fc27.x86_64/build M=/home/th3v0id/Personal/Repos/Diamorphine modules
make[1]: Entering directory '/usr/src/kernels/4.18.19-100.fc27.x86_64'
  CC [M]  /home/th3v0id/Personal/Repos/Diamorphine/diamorphine.o
  Building modules, stage 2.
  MODPOST 1 modules
  CC      /home/th3v0id/Personal/Repos/Diamorphine/diamorphine.mod.o
  LD [M]  /home/th3v0id/Personal/Repos/Diamorphine/diamorphine.ko
make[1]: Leaving directory '/usr/src/kernels/4.18.19-100.fc27.x86_64'
```

